### PR TITLE
[SETL-125] Make the creation of customized connector and the connector builder integration easie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 New Features:
 - Added Spark 3.0 support
 
+Changes:
+- Added `ConnectorInterface` to support custom connectors
+
 Fixes:
 - Fixed save mode in DynamoDB Connector
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ New Features:
 
 Changes:
 - Added `ConnectorInterface` to support custom connectors
+- Changed default hadoop version to 3.2.0
 
 Fixes:
 - Fixed save mode in DynamoDB Connector

--- a/README.md
+++ b/README.md
@@ -189,6 +189,41 @@ Add this factory into the pipeline:
 pipeline.addStage[AnotherFactory]()
 ```
 
+### Custom Connector
+
+You can implement you own data source connector by implementing the `ConnectorInterface`
+
+```scala
+class CustomConnector extends ConnectorInterface with CanDrop {
+  override def setConf(conf: Conf): Unit = null
+
+  override def setConfig(config: Config): Unit = null
+
+  override def read(): DataFrame = {
+    import spark.implicits._
+    Seq(1, 2, 3).toDF("id")
+  }
+
+  override def write(t: DataFrame, suffix: Option[String]): Unit = log.debug("Write with suffix")
+
+  override def write(t: DataFrame): Unit = log.debug("Write")
+
+  /**
+   * Drop the entire table.
+   */
+  override def drop(): Unit = log.debug("drop")
+}
+```
+
+To use it, just set the storage to **OTHER** and provide the class reference of your connector:
+
+```txt
+myConnector {
+  storage = "OTHER"
+  class = "com.example.CustomConnector"  // class reference of your connector 
+}
+```
+
 ### Generate pipeline diagram (with v0.4.1+)
 
 You can generate a [Mermaid diagram](https://mermaid-js.github.io/mermaid/#/) by doing:

--- a/docs/CustomConnector.md
+++ b/docs/CustomConnector.md
@@ -1,0 +1,34 @@
+## Custom Connector
+
+You can implement you own data source connector by implementing the `ConnectorInterface`
+
+```scala
+class CustomConnector extends ConnectorInterface with CanDrop {
+  override def setConf(conf: Conf): Unit = null
+
+  override def setConfig(config: Config): Unit = null
+
+  override def read(): DataFrame = {
+    import spark.implicits._
+    Seq(1, 2, 3).toDF("id")
+  }
+
+  override def write(t: DataFrame, suffix: Option[String]): Unit = log.debug("Write with suffix")
+
+  override def write(t: DataFrame): Unit = log.debug("Write")
+
+  /**
+   * Drop the entire table.
+   */
+  override def drop(): Unit = log.debug("drop")
+}
+```
+
+To use it, just set the storage to **OTHER** and provide the class reference of your connector:
+
+```txt
+myConnector {
+  storage = "OTHER"
+  class = "com.example.CustomConnector"  // class reference of your connector 
+}
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,7 @@ If you’re a **data scientist** or **data engineer**, this might sound familiar
     - [FileConnector](Connector#fileconnector)
     - [DBConnector](Connector#dbconnector)
     - [StructuredStreamingConnector](Structured-Streaming-Connector)
+    - [Use your own connector](CustomConnector)
   - [Repository](Repository)
   - [SparkRepositoryAdapter](SparkRepositoryAdapter)
   - [ConnectorBuilder](ConnectorBuilder)

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <changelist>-SNAPSHOT</changelist>
         <java.version>1.8</java.version>
         <app.environment>local</app.environment>
-        <apache.hadoop.version>3.3.0</apache.hadoop.version>
+        <apache.hadoop.version>3.2.0</apache.hadoop.version>
         <delta.version>0.7.0</delta.version>
         <scala.version>2.12.10</scala.version>
         <scala.compat.version>2.12</scala.compat.version>

--- a/src/main/scala/com/jcdecaux/setl/internal/HasReader.scala
+++ b/src/main/scala/com/jcdecaux/setl/internal/HasReader.scala
@@ -1,0 +1,9 @@
+package com.jcdecaux.setl.internal
+
+import org.apache.spark.sql.DataFrameReader
+
+trait HasReader {
+
+  protected val reader: DataFrameReader
+
+}

--- a/src/main/scala/com/jcdecaux/setl/internal/HasReaderWriter.scala
+++ b/src/main/scala/com/jcdecaux/setl/internal/HasReaderWriter.scala
@@ -1,0 +1,5 @@
+package com.jcdecaux.setl.internal
+
+trait HasReaderWriter extends HasReader with HasWriter {
+
+}

--- a/src/main/scala/com/jcdecaux/setl/internal/HasWriter.scala
+++ b/src/main/scala/com/jcdecaux/setl/internal/HasWriter.scala
@@ -1,0 +1,9 @@
+package com.jcdecaux.setl.internal
+
+import org.apache.spark.sql.{DataFrame, DataFrameWriter, Row}
+
+trait HasWriter {
+
+  protected val writer: DataFrame => DataFrameWriter[Row]
+
+}

--- a/src/main/scala/com/jcdecaux/setl/storage/ConnectorBuilder.scala
+++ b/src/main/scala/com/jcdecaux/setl/storage/ConnectorBuilder.scala
@@ -10,31 +10,39 @@ import com.jcdecaux.setl.exception.UnknownException
 import com.jcdecaux.setl.storage.connector._
 import com.jcdecaux.setl.util.TypesafeConfigUtils
 import com.typesafe.config.Config
-import org.apache.spark.sql.SparkSession
 
 /**
  * ConnectorBuilder will build a [[com.jcdecaux.setl.storage.connector.Connector]] object with the given
  * configuration.
  *
- * @param config optional, a [[com.typesafe.config.Config]] object
- * @param conf   optional, a [[com.jcdecaux.setl.config.Conf]] object
+ * @param config either a [[com.typesafe.config.Config]] or a [[com.jcdecaux.setl.config.Conf]] object
  */
 @InterfaceStability.Evolving
-class ConnectorBuilder(val config: Option[Config],
-                       val conf: Option[Conf]) extends Builder[Connector] {
+class ConnectorBuilder(val config: Either[Config, Conf]) extends Builder[Connector] {
 
-  def this(config: Config) = this(Some(config), None)
+  private[setl] def this(config: Option[Config], conf: Option[Conf]) = this(
+    (config, conf) match {
+      case (Some(c), None) => Left(c)
+      case (None, Some(c)) => Right(c)
+      case (_, _) => throw new IllegalArgumentException("Can't build connector with redundant configurations")
+    }
+  )
 
-  def this(conf: Conf) = this(None, Some(conf))
+  /**
+   * ConnectorBuilder will build a [[com.jcdecaux.setl.storage.connector.Connector]] object with the given
+   * configuration.
+   *
+   * @param config a [[com.typesafe.config.Config]] object
+   */
+  def this(config: Config) = this(Left(config))
 
-  @deprecated("use the constructor with no spark session", "0.3.4")
-  def this(spark: SparkSession, config: Option[Config], conf: Option[Conf]) = this(config, conf)
-
-  @deprecated("use the constructor with no spark session", "0.3.4")
-  def this(spark: SparkSession, config: Config) = this(Some(config), None)
-
-  @deprecated("use the constructor with no spark session", "0.3.4")
-  def this(spark: SparkSession, conf: Conf) = this(None, Some(conf))
+  /**
+   * ConnectorBuilder will build a [[com.jcdecaux.setl.storage.connector.Connector]] object with the given
+   * configuration.
+   *
+   * @param conf a [[com.jcdecaux.setl.config.Conf]] object
+   */
+  def this(conf: Conf) = this(Right(conf))
 
   private[this] var connector: Connector = _
 
@@ -42,12 +50,48 @@ class ConnectorBuilder(val config: Option[Config],
    * Build a connector
    */
   override def build(): ConnectorBuilder.this.type = {
-    connector = (config, conf) match {
-      case (Some(c), None) => buildConnectorWithConfig(c)
-      case (None, Some(c)) => buildConnectorWithConf(c)
-      case (_, _) => throw new IllegalArgumentException("Can't build connector with redundant configurations")
-    }
+    connector = buildConnector(config)
     this
+  }
+
+  /**
+   * Build a connector from either a [[com.typesafe.config.Config]] or a [[com.jcdecaux.setl.config.Conf]] object.
+   *
+   * the `config` object must have a key `storage` and the parameters corresponding to the storage
+   *
+   * @param config either a [[com.typesafe.config.Config]] or a [[com.jcdecaux.setl.config.Conf]] object
+   * @return [[com.jcdecaux.setl.storage.connector.Connector]] a connector object
+   */
+  private[this] def buildConnector(config: Either[Config, Conf]): Connector = {
+    val storage = config match {
+      case Left(c) =>
+        TypesafeConfigUtils.getAs[Storage](c, "storage")
+      case Right(c) =>
+        c.getAs[Storage]("storage")
+    }
+
+    require(storage.nonEmpty)
+
+    val argClass = if (config.isLeft) {
+      classOf[Config]
+    } else {
+      classOf[Conf]
+    }
+
+    log.debug(s"Build ${storage.get} connector with ${argClass.getCanonicalName}")
+
+    if (storage.get != Storage.OTHER) {
+      val constructor = connectorConstructorOf(storage.get, argClass)
+      constructor.newInstance(
+        config match {
+          case Left(c) => c
+          case Right(c) => c
+        }
+      )
+    } else {
+      throw new UnknownException.Storage(s"Storage $storage is not supported")
+    }
+
   }
 
   /**
@@ -65,41 +109,6 @@ class ConnectorBuilder(val config: Option[Config],
     val cst = Class.forName(storage.connectorName()).getDeclaredConstructor(constructorArgs: _*)
     cst.setAccessible(true)
     cst.asInstanceOf[Constructor[Connector]]
-  }
-
-  /**
-   * Build a connector from a [[com.jcdecaux.setl.config.Conf]] object.
-   *
-   * the `Conf` object must have a key `storage` and the parameters corresponding to the storage
-   *
-   * @param configuration [[com.jcdecaux.setl.config.Conf]] configuration
-   * @return [[com.jcdecaux.setl.storage.connector.Connector]] a connector object
-   */
-  private[this] def buildConnectorWithConf(configuration: Conf): Connector = {
-    configuration.getAs[Storage]("storage") match {
-      case Some(s) =>
-        val constructor = connectorConstructorOf(s, classOf[Conf])
-        constructor.newInstance(configuration)
-      case _ => throw new UnknownException.Storage("Unknown storage type")
-    }
-  }
-
-  /**
-   * Build a connector from a [[com.typesafe.config.Config]] object.
-   *
-   * the `Config` object must have a key `storage` and the parameters corresponding to the storage
-   *
-   * @param configuration a [[com.typesafe.config.Config]] object
-   * @return a [[com.jcdecaux.setl.storage.connector.Connector]]
-   */
-  private[this] def buildConnectorWithConfig(configuration: Config): Connector = {
-
-    TypesafeConfigUtils.getAs[Storage](configuration, "storage") match {
-      case Some(s) =>
-        val constructor = connectorConstructorOf(s, classOf[Config])
-        constructor.newInstance(configuration)
-      case _ => throw new UnknownException.Storage("Unknown storage type")
-    }
   }
 
   override def get(): Connector = connector

--- a/src/main/scala/com/jcdecaux/setl/storage/ConnectorBuilder.scala
+++ b/src/main/scala/com/jcdecaux/setl/storage/ConnectorBuilder.scala
@@ -70,7 +70,7 @@ class ConnectorBuilder(val config: Either[Config, Conf]) extends Builder[Connect
         c.getAs[Storage]("storage")
     }
 
-    require(storage.nonEmpty)
+    require(storage.nonEmpty, "Storage type is not defined")
 
     val argClass = if (config.isLeft) {
       classOf[Config]

--- a/src/main/scala/com/jcdecaux/setl/storage/SparkRepositoryBuilder.scala
+++ b/src/main/scala/com/jcdecaux/setl/storage/SparkRepositoryBuilder.scala
@@ -152,13 +152,7 @@ class SparkRepositoryBuilder[DataType: ru.TypeTag](var storage: Option[Storage],
     config match {
       case Some(typeSafeConfig) =>
         log.debug("Build connector with TypeSafe configuration")
-        try {
-          return new ConnectorBuilder(typeSafeConfig).build().get()
-        } catch {
-          case _: UnknownException.Storage => log.error("Unknown storage type in connector configuration")
-          case e: Throwable => throw e
-        }
-
+        return new ConnectorBuilder(typeSafeConfig).build().get()
       case _ =>
     }
 

--- a/src/main/scala/com/jcdecaux/setl/storage/SparkRepositoryBuilder.scala
+++ b/src/main/scala/com/jcdecaux/setl/storage/SparkRepositoryBuilder.scala
@@ -128,6 +128,8 @@ class SparkRepositoryBuilder[DataType: ru.TypeTag](var storage: Option[Storage],
 
   def setWorkbookPassword(pwd: String): this.type = set("workbookPassword", pwd)
 
+  def setCustomConnectorClass(cls: String): this.type = set(ConnectorBuilder.CLASS, cls)
+
   /**
    * Build an object
    *

--- a/src/main/scala/com/jcdecaux/setl/storage/connector/CassandraConnector.scala
+++ b/src/main/scala/com/jcdecaux/setl/storage/connector/CassandraConnector.scala
@@ -6,6 +6,7 @@ import com.datastax.spark.connector.cql.{CassandraConnector => DatastaxCassandra
 import com.jcdecaux.setl.annotation.InterfaceStability
 import com.jcdecaux.setl.config.Conf
 import com.jcdecaux.setl.enums.Storage
+import com.jcdecaux.setl.internal.HasReaderWriter
 import com.jcdecaux.setl.util.TypesafeConfigUtils
 import com.typesafe.config.Config
 import org.apache.spark.sql._
@@ -18,7 +19,7 @@ import org.apache.spark.sql.cassandra._
 class CassandraConnector(val keyspace: String,
                          val table: String,
                          val partitionKeyColumns: Option[Seq[String]],
-                         val clusteringKeyColumns: Option[Seq[String]]) extends DBConnector {
+                         val clusteringKeyColumns: Option[Seq[String]]) extends DBConnector with HasReaderWriter {
 
   def this(keyspace: String,
            table: String,

--- a/src/main/scala/com/jcdecaux/setl/storage/connector/Connector.scala
+++ b/src/main/scala/com/jcdecaux/setl/storage/connector/Connector.scala
@@ -23,10 +23,6 @@ trait Connector extends HasSparkSession with Logging {
 
   val storage: Storage
 
-  protected val reader: DataFrameReader
-
-  protected val writer: DataFrame => DataFrameWriter[Row]
-
   def read(): DataFrame
 
   def write(t: DataFrame, suffix: Option[String]): Unit
@@ -40,8 +36,6 @@ object Connector {
   def empty: Connector = new Connector {
     override val spark: SparkSession = null
     override val storage: Storage = null
-    override val reader: DataFrameReader = null
-    override val writer: DataFrame => DataFrameWriter[Row] = null
     override def read(): DataFrame = null
     override def write(t: DataFrame, suffix: Option[String]): Unit = {}
     override def write(t: DataFrame): Unit = {}

--- a/src/main/scala/com/jcdecaux/setl/storage/connector/ConnectorInterface.scala
+++ b/src/main/scala/com/jcdecaux/setl/storage/connector/ConnectorInterface.scala
@@ -1,0 +1,18 @@
+package com.jcdecaux.setl.storage.connector
+import com.jcdecaux.setl.config.Conf
+import com.jcdecaux.setl.enums.Storage
+import com.typesafe.config.Config
+
+/**
+ * ConnectorInterface provides the abstraction of a pluggable connector that could be used by [[com.jcdecaux.setl.storage.ConnectorBuilder]].
+ * Users can implement their customized data source connector by extending this trait.
+ */
+trait ConnectorInterface extends Connector {
+
+  override val storage: Storage = Storage.OTHER
+
+  def setConf(conf: Conf): Unit
+
+  def setConfig(config: Config): Unit
+
+}

--- a/src/main/scala/com/jcdecaux/setl/storage/connector/DeltaConnector.scala
+++ b/src/main/scala/com/jcdecaux/setl/storage/connector/DeltaConnector.scala
@@ -2,6 +2,7 @@ package com.jcdecaux.setl.storage.connector
 
 import com.jcdecaux.setl.config.{Conf, DeltaConnectorConf}
 import com.jcdecaux.setl.enums.Storage
+import com.jcdecaux.setl.internal.HasReaderWriter
 import com.jcdecaux.setl.util.TypesafeConfigUtils
 import com.typesafe.config.Config
 import io.delta.tables.DeltaTable
@@ -14,7 +15,7 @@ import scala.collection.mutable.ArrayBuffer
 /**
  * DeltaConnector contains functionality for transforming [[DataFrame]] into DeltaLake files
  */
-class DeltaConnector(val options: DeltaConnectorConf) extends ACIDConnector  {
+class DeltaConnector(val options: DeltaConnectorConf) extends ACIDConnector with HasReaderWriter  {
 
   val storage = Storage.DELTA
 

--- a/src/main/scala/com/jcdecaux/setl/storage/connector/DynamoDBConnector.scala
+++ b/src/main/scala/com/jcdecaux/setl/storage/connector/DynamoDBConnector.scala
@@ -3,6 +3,7 @@ package com.jcdecaux.setl.storage.connector
 import com.jcdecaux.setl.annotation.InterfaceStability
 import com.jcdecaux.setl.config.{Conf, DynamoDBConnectorConf}
 import com.jcdecaux.setl.enums.Storage
+import com.jcdecaux.setl.internal.HasReaderWriter
 import com.jcdecaux.setl.util.TypesafeConfigUtils
 import com.typesafe.config.Config
 import org.apache.spark.sql._
@@ -21,7 +22,7 @@ import org.apache.spark.sql._
  * }}}
  */
 @InterfaceStability.Evolving
-class DynamoDBConnector(val conf: DynamoDBConnectorConf) extends DBConnector {
+class DynamoDBConnector(val conf: DynamoDBConnectorConf) extends DBConnector with HasReaderWriter {
 
   def this(conf: Map[String, String]) = this(new DynamoDBConnectorConf().set(conf))
 

--- a/src/main/scala/com/jcdecaux/setl/storage/connector/ExcelConnector.scala
+++ b/src/main/scala/com/jcdecaux/setl/storage/connector/ExcelConnector.scala
@@ -3,6 +3,7 @@ package com.jcdecaux.setl.storage.connector
 import com.jcdecaux.setl.annotation.InterfaceStability
 import com.jcdecaux.setl.config.Conf
 import com.jcdecaux.setl.enums.Storage
+import com.jcdecaux.setl.internal.HasReaderWriter
 import com.jcdecaux.setl.util.TypesafeConfigUtils
 import com.typesafe.config.Config
 import org.apache.spark.sql._
@@ -40,7 +41,7 @@ class ExcelConnector(val path: String,
                      var workbookPassword: Option[String],
                      var schema: Option[StructType],
                      var saveMode: SaveMode
-                    ) extends Connector {
+                    ) extends Connector with HasReaderWriter {
 
   // CONSTRUCTORS
   def this(spark: SparkSession,

--- a/src/main/scala/com/jcdecaux/setl/storage/connector/FileConnector.scala
+++ b/src/main/scala/com/jcdecaux/setl/storage/connector/FileConnector.scala
@@ -7,6 +7,7 @@ import java.util.concurrent.locks.ReentrantLock
 
 import com.jcdecaux.setl.annotation.InterfaceStability
 import com.jcdecaux.setl.config.FileConnectorConf
+import com.jcdecaux.setl.internal.HasReaderWriter
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, LocalFileSystem, Path}
 import org.apache.spark.sql._
@@ -17,7 +18,7 @@ import scala.collection.mutable.ArrayBuffer
 import scala.util.matching.Regex
 
 @InterfaceStability.Evolving
-abstract class FileConnector(val options: FileConnectorConf) extends Connector {
+abstract class FileConnector(val options: FileConnectorConf) extends Connector with HasReaderWriter {
 
   def this(options: Map[String, String]) = this(FileConnectorConf.fromMap(options))
 

--- a/src/main/scala/com/jcdecaux/setl/storage/connector/JDBCConnector.scala
+++ b/src/main/scala/com/jcdecaux/setl/storage/connector/JDBCConnector.scala
@@ -4,12 +4,13 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 import com.jcdecaux.setl.config.{Conf, JDBCConnectorConf}
 import com.jcdecaux.setl.enums.Storage
+import com.jcdecaux.setl.internal.HasReaderWriter
 import com.jcdecaux.setl.util.{SparkUtils, TypesafeConfigUtils}
 import com.typesafe.config.Config
 import org.apache.spark.sql._
 import org.apache.spark.sql.execution.datasources.jdbc._
 
-class JDBCConnector(val conf: JDBCConnectorConf) extends DBConnector {
+class JDBCConnector(val conf: JDBCConnectorConf) extends DBConnector with HasReaderWriter {
 
   private[this] val _read: AtomicBoolean = new AtomicBoolean(false)
   private[this] val _source: String = s"JDBCRelation(${conf.getDbTable.get})"

--- a/src/main/scala/com/jcdecaux/setl/storage/connector/StructuredStreamingConnector.scala
+++ b/src/main/scala/com/jcdecaux/setl/storage/connector/StructuredStreamingConnector.scala
@@ -30,9 +30,6 @@ class StructuredStreamingConnector(val conf: StructuredStreamingConnectorConf) e
 
   override val storage: Storage = Storage.STRUCTURED_STREAMING
 
-  override protected val reader: DataFrameReader = null
-  override protected val writer: DataFrame => DataFrameWriter[Row] = null
-
   @inline protected val streamReader: DataStreamReader = spark.readStream
     .format(conf.getFormat)
     .options(conf.getReaderConf)

--- a/src/test/resources/test_connector_builder.conf
+++ b/src/test/resources/test_connector_builder.conf
@@ -1,0 +1,4 @@
+customConnector {
+  storage = "OTHER"
+  class = "com.jcdecaux.setl.CustomConnector"
+}

--- a/src/test/scala/com/jcdecaux/setl/TestObject.scala
+++ b/src/test/scala/com/jcdecaux/setl/TestObject.scala
@@ -3,6 +3,7 @@ package com.jcdecaux.setl
 import java.sql.{Date, Timestamp}
 
 import com.jcdecaux.setl.config.Conf
+import com.jcdecaux.setl.internal.CanDrop
 import com.jcdecaux.setl.storage.connector.ConnectorInterface
 import com.typesafe.config.Config
 import org.apache.spark.sql.DataFrame
@@ -14,7 +15,7 @@ case class TestObject3(partition1: Int, partition2: String, clustering1: String,
 
 case class TestObject2(col1: String, col2: Int, col3: Double, col4: Timestamp, col5: Date, col6: Long)
 
-class CustomConnector extends ConnectorInterface {
+class CustomConnector extends ConnectorInterface with CanDrop {
   override def setConf(conf: Conf): Unit = null
 
   override def setConfig(config: Config): Unit = null
@@ -27,4 +28,9 @@ class CustomConnector extends ConnectorInterface {
   override def write(t: DataFrame, suffix: Option[String]): Unit = log.debug("Write with suffix")
 
   override def write(t: DataFrame): Unit = log.debug("Write")
+
+  /**
+   * Drop the entire table.
+   */
+  override def drop(): Unit = log.debug("drop")
 }

--- a/src/test/scala/com/jcdecaux/setl/TestObject.scala
+++ b/src/test/scala/com/jcdecaux/setl/TestObject.scala
@@ -2,9 +2,29 @@ package com.jcdecaux.setl
 
 import java.sql.{Date, Timestamp}
 
+import com.jcdecaux.setl.config.Conf
+import com.jcdecaux.setl.storage.connector.ConnectorInterface
+import com.typesafe.config.Config
+import org.apache.spark.sql.DataFrame
+
 
 case class TestObject(partition1: Int, partition2: String, clustering1: String, value: Long)
 
 case class TestObject3(partition1: Int, partition2: String, clustering1: String, value: Long, value2: String)
 
 case class TestObject2(col1: String, col2: Int, col3: Double, col4: Timestamp, col5: Date, col6: Long)
+
+class CustomConnector extends ConnectorInterface {
+  override def setConf(conf: Conf): Unit = null
+
+  override def setConfig(config: Config): Unit = null
+
+  override def read(): DataFrame = {
+    import spark.implicits._
+    Seq(1, 2, 3).toDF("id")
+  }
+
+  override def write(t: DataFrame, suffix: Option[String]): Unit = log.debug("Write with suffix")
+
+  override def write(t: DataFrame): Unit = log.debug("Write")
+}

--- a/src/test/scala/com/jcdecaux/setl/config/Properties.scala
+++ b/src/test/scala/com/jcdecaux/setl/config/Properties.scala
@@ -39,7 +39,7 @@ object Properties {
 
 
   val wrongCsvConfigConnectorBuilder: Config = cl.getConfig("connectorBuilder.wrong_csv")
-  val wrongCsvConfigConnectorBuilder2: Config = cl.getConfig("connectorBuilder.wrong_csv2")
+  val customConnectorWithoutRef: Config = cl.getConfig("connectorBuilder.wrong_csv2")
   val parquetConfigConnectorBuilder: Config = cl.getConfig("connectorBuilder.parquet")
 
 

--- a/src/test/scala/com/jcdecaux/setl/storage/ConnectorBuilderSuite.scala
+++ b/src/test/scala/com/jcdecaux/setl/storage/ConnectorBuilderSuite.scala
@@ -35,9 +35,9 @@ class ConnectorBuilderSuite extends AnyFunSuite with BeforeAndAfterAll {
     val connector = new ConnectorBuilder(Properties.csvConfigConnectorBuilder).build().get()
     connector.write(testTable.toDF())
 
-    val connector2 = new ConnectorBuilder(spark, Some(Properties.csvConfigConnectorBuilder), None).build().get()
-    val connector3 = new ConnectorBuilder(spark, Properties.csvConfigConnectorBuilder).build().get()
-    val connector4 = new ConnectorBuilder(spark, conf).build().get()
+    val connector2 = new ConnectorBuilder(Some(Properties.csvConfigConnectorBuilder), None).build().get()
+    val connector3 = new ConnectorBuilder(Properties.csvConfigConnectorBuilder).build().get()
+    val connector4 = new ConnectorBuilder(conf).build().get()
 
     assert(connector.read().count() === 3)
     assert(connector2.read().count() === 3)

--- a/src/test/scala/com/jcdecaux/setl/storage/SparkRepositoryBuilderSuite.scala
+++ b/src/test/scala/com/jcdecaux/setl/storage/SparkRepositoryBuilderSuite.scala
@@ -338,8 +338,9 @@ class SparkRepositoryBuilderSuite extends AnyFunSuite {
       .setEnv("local")
       .getOrCreate()
 
-    // UnknownException.Storage should be thrown if the given storage type is not supported
-    assertThrows[UnknownException.Storage](new SparkRepositoryBuilder[TestObject](Storage.OTHER).build())
+    assertThrows[IllegalArgumentException](new SparkRepositoryBuilder[TestObject](Storage.OTHER).build(),
+      "IllegalArgumentException should be thrown if storage = OTHER and no available class reference is provided"
+    )
 
     // NoSuchElementException should be thrown if missing arguments
     assertThrows[InvocationTargetException](new SparkRepositoryBuilder[TestObject](Storage.CSV).build())
@@ -353,7 +354,7 @@ class SparkRepositoryBuilderSuite extends AnyFunSuite {
       .setEnv("local")
       .getOrCreate()
 
-    if(checkSparkVersion.isDefined) {
+    if (checkSparkVersion.isDefined) {
       assume(SparkTestUtils.checkSparkVersion(checkSparkVersion.get))
     }
 

--- a/src/test/scala/com/jcdecaux/setl/storage/SparkRepositoryBuilderSuite.scala
+++ b/src/test/scala/com/jcdecaux/setl/storage/SparkRepositoryBuilderSuite.scala
@@ -30,7 +30,7 @@ class SparkRepositoryBuilderSuite extends AnyFunSuite {
     assert(builder.getAs[String]("path").get === "my/test/path")
 
     val builder2 = new SparkRepositoryBuilder[TestObject]()
-    assertThrows[com.jcdecaux.setl.exception.UnknownException.Storage](builder2.build())
+    assertThrows[IllegalArgumentException](builder2.build())
 
     val builder3 = new SparkRepositoryBuilder[TestObject](spark)
     builder3.setPath("my/test/path")
@@ -92,7 +92,7 @@ class SparkRepositoryBuilderSuite extends AnyFunSuite {
   test("SparkRepository build with typesafe config") {
     val conf = ConfigFactory.load("test_priority.conf")
     val builder = new SparkRepositoryBuilder[TestObject](conf)
-    assertThrows[UnknownException.Storage](builder.build())
+    assertThrows[IllegalArgumentException](builder.build())
   }
 
   test("SparkRepository cassandra") {


### PR DESCRIPTION
I added a new trait `ConnectorInterface`.

Users who want to use a customized connector can implement this trait. Then in the configuration, storage must be set to "OTHER" and the class name of the custom connector must be provided. `ConnectorBuilder` should be able to handle the instantiation and the configuration of the custom connector. (see readme)

close #125 
